### PR TITLE
improve performance of :clj equivalent-byte-arrays?

### DIFF
--- a/src/deercreeklabs/baracus.cljc
+++ b/src/deercreeklabs/baracus.cljc
@@ -78,7 +78,7 @@
    checks identity, not equality. Note that this is an O(n) operation."
   [a :- ByteArray
    b :- ByteArray]
-  #?(:clj (java.util.Arrays/equals a b)
+  #?(:clj (Arrays/equals a b)
      :cljs (and
              (= (count a) (count b))
              (let [num (count a)]

--- a/src/deercreeklabs/baracus.cljc
+++ b/src/deercreeklabs/baracus.cljc
@@ -38,7 +38,6 @@
     (boolean (= ByteArray
                 (#?(:clj class :cljs type) arg)))))
 
-
 (s/defn byte-array :- ByteArray
   "Construct a byte array.
    Args:
@@ -79,16 +78,17 @@
    checks identity, not equality. Note that this is an O(n) operation."
   [a :- ByteArray
    b :- ByteArray]
-  (and
-   (= (count a) (count b))
-   (let [num (count a)]
-     (loop [i 0]
-       (if (>= i num)
-         true
-         (if (= (aget ^bytes a i)
-                (aget ^bytes b i))
-           (recur (int (inc i)))
-           false))))))
+  #?(:clj (java.util.Arrays/equals a b)
+     :cljs (and
+             (= (count a) (count b))
+             (let [num (count a)]
+               (loop [i 0]
+                 (if (>= i num)
+                   true
+                   (if (= (aget ^bytes a i)
+                          (aget ^bytes b i))
+                     (recur (int (inc i)))
+                     false)))))))
 
 (s/defn byte-array->debug-str :- s/Str
   [ba :- ByteArray]


### PR DESCRIPTION
Using `{:extra-deps {com.taoensso/tufte {:mvn/version "2.2.0"}}}` and
```Clojure
(tufte/add-basic-println-handler! {})
(tufte/profile
  {}
  (dotimes [_ 5]
    (tufte/p :equivalent-byte-arrays?
             (equivalent-byte-arrays? (byte-array 1000000000)
                                      (byte-array 1000000000)))))
```
I see a before and after mean of 2.06s vs 419.83ms.
```
;; Before
pId                          nCalls        Min      50% ≤      90% ≤      95% ≤      99% ≤        Max       Mean   MAD      Clock  Total

:equivalent-byte-arrays?          5     1.70s      1.71s      2.72s      2.72s      2.72s      2.72s      2.06s   ±21%    10.30s    100%

Accounted                                                                                                                 10.30s    100%
Clock                                                                                                                     10.30s    100%
```

```
;; After
pId                          nCalls        Min      50% ≤      90% ≤      95% ≤      99% ≤        Max       Mean   MAD      Clock  Total

:equivalent-byte-arrays?          5   197.17ms   240.79ms     1.07s      1.07s      1.07s      1.07s    419.83ms  ±62%     2.10s    100%

Accounted                                                                                                                  2.10s    100%
Clock                                                                                                                      2.10s    100%
```

I'm not sure if there's a reason not to do this that you may have already thought of and hence didn't do this in the first place. Since we have byte arrays specifically here, not arrays of objects, this shallow check should be sufficient I think. I was just trying to familiarize myself by reading the code base and had this thought to try `java.util.Arrays/equals`. I don't know of a better way in JS off the top of my head.